### PR TITLE
fix DCS Marker coordinate since 2.5.5.34644 Open Beta

### DIFF
--- a/src/scripts/veafMarkers.lua
+++ b/src/scripts/veafMarkers.lua
@@ -43,7 +43,7 @@ veafMarkers.Id = "MARKERS - "
 veafMarkers.Version = "1.1.0"
 
 --- DCS bug regarding wrong marker vector components was fixed. If so, set to true!
-veafMarkers.DCSbugfixed = false
+veafMarkers.DCSbugfixed = true
 
 veafMarkers.markerEventsTraceMessages = false
 veafMarkers.markerEventsDebugMessages = false


### PR DESCRIPTION
close #37 

be careful, this fix break Stable compatibility for spawn units mecanisms.. 